### PR TITLE
feat: Add entrypoint script for Render deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,11 +24,12 @@ RUN python -m spacy download en_core_web_sm
 # Copy your application code
 COPY . .
 
+# --- Make entrypoint script executable and set it as the command ---
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
 # --- Expose the Port ---
 EXPOSE 5000
 
 # --- Define the Production Start Command ---
-# We will use a build script to handle database migrations
-# The CMD will be set in the render.yaml or Render UI
-# For now, Gunicorn is the final command.
-CMD ["gunicorn", "--bind", "0.0.0.0:5000", "--workers", "4", "main:app"]
+CMD ["/app/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Run database migrations
+echo "Running database migrations..."
+flask db upgrade
+
+# Start Gunicorn
+echo "Starting Gunicorn..."
+exec gunicorn --bind 0.0.0.0:5000 --workers 4 main:app


### PR DESCRIPTION
- Create entrypoint.sh to run database migrations and start Gunicorn.
- Update Dockerfile to use the new entrypoint script.
- This approach is compatible with Render's free tier.